### PR TITLE
set prctl PR_SET_DEATHSIG for the log-user-session processes

### DIFF
--- a/src/log-user-session.c
+++ b/src/log-user-session.c
@@ -99,6 +99,7 @@
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
+#include <sys/prctl.h>
 
 
 /* log directory is predefined so that it cannot be change by the user */
@@ -700,6 +701,9 @@ void start_logger(const char *log_file, const char *original_command, uid_t uid)
             exit(1);
         }
 
+        /* setup parent-death signal to SIGTERM, this prevents stale log childrens */
+        prctl(PR_SET_PDEATHSIG, SIGTERM);
+
         close(STDIN_FILENO);
         close(STDOUT_FILENO);
         close(STDERR_FILENO);
@@ -719,6 +723,9 @@ void start_logger(const char *log_file, const char *original_command, uid_t uid)
         child_tty = input.write_side;
         signal(SIGWINCH, resize_handler);
     }
+
+    /* setup parent-death signal to SIGTERM, this prevents stale log childrens */
+    prctl(PR_SET_PDEATHSIG, SIGTERM);
 
     /* do the logging */
     run_log_forwarder(&internal, &input, output,


### PR DESCRIPTION
Detail:
* instead of log-user-sessions processes getting reaped to the init
process, we want the kernel to signal us a dying parent so that we
can properly terminate